### PR TITLE
fix(helm): add resources block

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -94,6 +94,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.artifactory.secretName }}
                   key: token
+          resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.volumeMounts }}
           volumeMounts: {{- toYaml .Values.volumeMounts | nindent 12 }}
           {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -69,3 +69,13 @@ serviceAccount:
 
 # nodeSelector -- Node labels for constraining the coder-xray pod to specific nodes.
 nodeSelector: {}
+
+ # -- Resource limits and requests for the coder-xray pod
+resources: {}
+  #  limits:
+  #    cpu: 500m
+  #    memory: 512Mi
+  #  requests:
+  #    cpu: 250m
+  #    memory: 256Mi
+  


### PR DESCRIPTION
Add resources block to Helm chart to enable configuring limits & requests. This is required in environments that do not have default values.