### PR TITLE
fix(helm): remove `apps/events` from role

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -8,7 +8,7 @@ rules:
   resources: ["pods", "events"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["apps"]
-  resources: ["replicasets", "events"]
+  resources: ["replicasets"]
   verbs: ["get", "watch", "list"]
 ---
 apiVersion: v1


### PR DESCRIPTION
The `events` resource is not part of the `apps` API Group. Attempting to grant RBAC permissions not currently held (e.g., for resources that do not exist) can be blocked in certain environments, causing issues with the deployment.

The api groups/versions was verified by checking resources installed on Kubernetes v1.30 (as seen below) as well as reviewing the [Kubernetes Reference API Docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#event-v1-events-k8s-io)  for Kubernetes v1.33.
```bash
$ kubectl api-resources --sort-by name | grep events
NAME                                      SHORTNAMES                    APIVERSION                                  NAMESPACED   KIND
events                                    ev                            v1                                          true         Event
events                                    ev                            events.k8s.io/v1                            true         Event
```
Both confirm the absence of `events` under `apps`. 